### PR TITLE
[BUGFIX] Set WP-fastest-cache mobile directory to "wpfc-mobile-cache" instead of "all" (desktop)

### DIFF
--- a/globals/wp-fastest-cache.conf
+++ b/globals/wp-fastest-cache.conf
@@ -57,7 +57,7 @@ location / {
 # location to handle requests come from mobile devices
 location @mobileaccess {
     # look for cached version for mobiles; if-not-found, then send the request to PHP
-    try_files "/wp-content/cache/all/${uri}index.html" $uri $uri/ /index.php$is_args$args;
+    try_files "/wp-content/cache/wpfc-mobile-cache/${uri}index.html" $uri $uri/ /index.php$is_args$args;
 
     #--> all the following would apply, only if the request hits the cache
 


### PR DESCRIPTION
Normal directory = all
But when using mobile -> the newly created " wpfc-mobile-cache" is used for mobile calls.

Rewrite code to look in the wpfc-mobile-cache directory when user agent is mobile.